### PR TITLE
async-speedup

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,4 +7,5 @@
   :test-paths ["test"]
   :jvm-opts ["-Duser.timezone=GMT"]
   :main core-async-demo.core
-  :dependencies [[org.clojure/clojure "1.8.0"]])
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [org.clojure/core.async "0.2.374"]])

--- a/src/core_async_demo/core.clj
+++ b/src/core_async_demo/core.clj
@@ -1,5 +1,6 @@
 (ns core-async-demo.core
-  (:require [clojure.string :as s])
+  (:require [clojure.string :as s]
+            [clojure.core.async :as async])
   (:gen-class))
 
 (defn sleepy-transform
@@ -8,13 +9,21 @@
   (Thread/sleep 1000)
   (s/upper-case word))
 
+(defn parallel-transform
+  "An asyc wrapper for the sleepy-transform."
+  [result word]
+  (async/thread
+    (swap! result conj (sleepy-transform word))))
+
 (defn main
   []
   (time
     (let [input "Asynchronous programming is hard, but should it be?"
-          result (map sleepy-transform (s/split input #" "))]
+          result (atom [])]
+      (doseq [word (s/split input #" ")]
+        (parallel-transform result word))
       (println)
-      (println result)
+      (println @result)
       (println "All done!"))))
 
 (defn -main [& _]


### PR DESCRIPTION
# Motivation

Sleepy transform is far too slow. Parallelizing the work seems like the right way to go.
# Testing
## Functional
- Before:

```
(ASYNCHRONOUS PROGRAMMING IS HARD, BUT SHOULD IT BE?)
All done!
"Elapsed time: 8024.665007 msecs"
```
- After

```
[]
All done!
"Elapsed time: 1.735506 msecs"
```
# Notes

Definitely got a speedup, but nothing is printing now.
